### PR TITLE
Extend reporting functionality and implement some manipulation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage
 =====
 ```
 $ ./amd_ucode_info.py --help
-usage: amd_ucode_info.py [-h] [-e EXTRACT] [-v]
+usage: amd_ucode_info.py [-h] [-e EXTRACT] [-s SPLIT] [-v]
                          container_file [container_file ...]
 
 Print information about an amd-ucode container
@@ -21,6 +21,9 @@ options:
   -e EXTRACT, --extract EXTRACT
                         Dump each patch in container to the specified
                         directory
+  -s SPLIT, --split SPLIT
+                        Split out each patch in a separate container to the
+                        specified directory
   -v, --verbose         Increase output verbosity level: provide once to see
                         additional information about patches, twice to see all
                         the information available
@@ -45,5 +48,20 @@ Microcode patches in /lib/firmware/amd-ucode/microcode_amd_fam17h.bin:
     Patch extracted to /tmp/extract-here/mc_patch_08001250.bin
   Family=0x17 Model=0x08 Stepping=0x02: Patch=0x0800820d Length=3200 bytes
     Patch extracted to /tmp/extract-here/mc_patch_0800820d.bin
+```
+
+Instead of the raw patches, container can also be split out into multiple files,
+each containing only a single patch, but still useable by the linux kernel:
+```
+$ ./amd_ucode_info.py /lib/firmware/amd-ucode/microcode_amd_fam17h.bin -s /tmp/extract-here
+Microcode patches in /lib/firmware/amd-ucode/microcode_amd_fam17h.bin:
+  Family=0x17 Model=0x01 Stepping=0x02: Patch=0x08001250 Length=3200 bytes
+    Patch extracted to /tmp/extract-here/mc_equivid_0x8012_cpuid_0x00800f12_patch_0x08001250.bin
+  Family=0x17 Model=0x08 Stepping=0x02: Patch=0x0800820d Length=3200 bytes
+    Patch extracted to /tmp/extract-here/mc_equivid_0x8082_cpuid_0x00800f82_patch_0x0800820d.bin
+$ ./amd_ucode_info.py /tmp/extract-here/mc_equivid_0x8012_cpuid_0x00800f12_patch_0x08001250.bin
+Microcode patches in /tmp/extract-here/mc_equivid_0x8012_cpuid_0x00800f12_patch_0x08001250.bin:
+  Family=0x17 Model=0x01 Stepping=0x02: Patch=0x08001250 Length=3200 bytes
+
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage
 =====
 ```
 $ ./amd_ucode_info.py --help
-usage: amd_ucode_info.py [-h] [-e EXTRACT] [-s SPLIT] [-v]
+usage: amd_ucode_info.py [-h] [-e EXTRACT] [-s SPLIT] [-m MERGE] [-v]
                          container_file [container_file ...]
 
 Print information about an amd-ucode container
@@ -24,6 +24,8 @@ options:
   -s SPLIT, --split SPLIT
                         Split out each patch in a separate container to the
                         specified directory
+  -m MERGE, --merge MERGE
+                        Write a merged container to the specified file
   -v, --verbose         Increase output verbosity level: provide once to see
                         additional information about patches, twice to see all
                         the information available

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Usage
 =====
 ```
 $ ./amd_ucode_info.py --help
-usage: amd_ucode_info.py [-h] [-e EXTRACT] container_file [container_file ...]
+usage: amd_ucode_info.py [-h] [-e EXTRACT] [-v]
+                         container_file [container_file ...]
 
 Print information about an amd-ucode container
 
@@ -20,6 +21,9 @@ options:
   -e EXTRACT, --extract EXTRACT
                         Dump each patch in container to the specified
                         directory
+  -v, --verbose         Increase output verbosity level: provide once to see
+                        additional information about patches, twice to see all
+                        the information available
 ```
 
 To print information about a container file, pass the path to the container

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ kernel.
 Usage
 =====
 ```
-# ./amd_ucode_info.py --help
-usage: amd_ucode_info.py [-h] [-e EXTRACT] container_file
+$ ./amd_ucode_info.py --help
+usage: amd_ucode_info.py [-h] [-e EXTRACT] container_file [container_file ...]
 
 Print information about an amd-ucode container
 
 positional arguments:
   container_file
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -e EXTRACT, --extract EXTRACT
                         Dump each patch in container to the specified

--- a/amd_ucode_info.py
+++ b/amd_ucode_info.py
@@ -16,6 +16,9 @@ EQ_TABLE_ENTRY_SIZE = 16
 EQ_TABLE_LEN_OFFSET = 8
 EQ_TABLE_OFFSET = 12
 
+VERBOSE_DEBUG = 2
+
+
 def read_int32(ucode_file):
     """ Read four bytes of binary data and return as a 32 bit int """
     return int.from_bytes(ucode_file.read(4), 'little')
@@ -24,7 +27,11 @@ def read_int16(ucode_file):
     """ Read two bytes of binary data and return as a 16 bit int """
     return int.from_bytes(ucode_file.read(2), 'little')
 
-def parse_equiv_table(ucode_file, eq_table_len):
+def read_int8(ucode_file):
+    """ Read one byte of binary data and return as a 8 bit int """
+    return int.from_bytes(ucode_file.read(1), 'little')
+
+def parse_equiv_table(opts, ucode_file, eq_table_len):
     """
     Read equivalence table and return a list of the equivalence ids contained
     """
@@ -36,15 +43,29 @@ def parse_equiv_table(ucode_file, eq_table_len):
     while table_item < table_stop:
         ucode_file.seek(table_item, 0)
 
+        """
+        struct equiv_cpu_entry {
+            u32 installed_cpu;
+            u32 fixed_errata_mask;
+            u32 fixed_errata_compare;
+            u16 equiv_cpu;
+            u16 res;
+        } __packed;
+        """
         cpu_id = read_int32(ucode_file)
-
-        # Skip errata mask and compare fields
-        ucode_file.seek(8, 1)
-
+        errata_mask = read_int32(ucode_file)
+        errata_compare = read_int32(ucode_file)
         equiv_id = read_int16(ucode_file)
+        res = read_int16(ucode_file)
 
         if equiv_id != 0:
             table[equiv_id] = cpu_id
+
+        if opts.verbose >= VERBOSE_DEBUG:
+            print((" [equiv entry@%#010x: cpuid %#010x, equiv id %#06x, " +
+                   "errata mask %#010x, errata compare %#010x, res %#06x]") %
+                  (table_item, cpu_id, equiv_id, errata_mask, errata_compare,
+                   res))
 
         table_item += EQ_TABLE_ENTRY_SIZE
 
@@ -95,7 +116,7 @@ def parse_ucode_file(opts, path):
         ucode_file.seek(EQ_TABLE_LEN_OFFSET, 0)
         eq_table_len = read_int32(ucode_file)
 
-        ids = parse_equiv_table(ucode_file, eq_table_len)
+        ids = parse_equiv_table(opts, ucode_file, eq_table_len)
 
         cursor = EQ_TABLE_OFFSET + eq_table_len
         while cursor < end_of_file:
@@ -110,10 +131,46 @@ def parse_ucode_file(opts, path):
                 break
 
             patch_length = read_int32(ucode_file)
-            ucode_file.seek(4, 1)
+
+            """
+            struct microcode_header_amd {
+                u32 data_code;
+                u32 patch_id;
+                u16 mc_patch_data_id;
+                u8  mc_patch_data_len;
+                u8  init_flag;
+                u32 mc_patch_data_checksum;
+                u32 nb_dev_id;
+                u32 sb_dev_id;
+                u16 processor_rev_id;
+                u8  nb_rev_id;
+                u8  sb_rev_id;
+                u8  bios_api_rev;
+                u8  reserved1[3];
+                u32 match_reg[8];
+            } __packed;
+            """
+            data_code = read_int32(ucode_file)
             ucode_level = read_int32(ucode_file)
-            ucode_file.seek(16, 1)
+            mc_patch_data_id = read_int16(ucode_file)
+            mc_patch_data_len = read_int8(ucode_file)
+            init_flag = read_int8(ucode_file)
+            mc_patch_data_checksum = read_int32(ucode_file)
+            nb_dev_id = read_int32(ucode_file)
+            sb_dev_id = read_int32(ucode_file)
             equiv_id = read_int16(ucode_file)
+            nb_rev_id = read_int8(ucode_file)
+            sb_rev_id = read_int8(ucode_file)
+            bios_api_rev = read_int8(ucode_file)
+            reserved1 = [read_int8(ucode_file) for _ in range(3)]
+            match_reg = [read_int32(ucode_file) for _ in range(8)]
+
+            if opts.verbose:
+                add_info = " Start=%u bytes Date=%04x-%02x-%02x Equiv_id=%#06x" % \
+                           (patch_start, data_code & 0xffff, data_code >> 24,
+                            (data_code >> 16) & 0xff, equiv_id)
+            else:
+                add_info = ""
 
             if equiv_id not in ids:
                 print("Patch equivalence id not present in equivalence table (%#06x)"
@@ -133,8 +190,22 @@ def parse_ucode_file(opts, path):
 
             stepping = cpu_id & 0xf
 
-            print("  Family=%#04x Model=%#04x Stepping=%#04x: Patch=%#010x Length=%u bytes"
-                  % (family, model, stepping, ucode_level, patch_length))
+            print("  Family=%#04x Model=%#04x Stepping=%#04x: Patch=%#010x Length=%u bytes%s"
+                  % (family, model, stepping, ucode_level, patch_length, add_info))
+
+            if opts.verbose >= VERBOSE_DEBUG:
+                print(("   [data_code=%#010x, mc_patch_data_id=%#06x, " +
+                       "mc_patch_data_len=%#04x, init_flag=%#04x, " +
+                       "mc_patch_data_checksum=%#010x]") %
+                      (data_code, mc_patch_data_id, mc_patch_data_len,
+                       init_flag, mc_patch_data_checksum))
+                print(("   [nb_dev_id=%#010x, sb_dev_id=%#010x, " +
+                       "nb_rev_id=%#04x, sb_rev_id=%#04x, " +
+                       "bios_api_rev=%#04x, reserved=[%#04x, %#04x, %#04x]]") %
+                      (nb_dev_id, sb_dev_id, nb_rev_id, sb_rev_id,
+                       bios_api_rev, reserved1[0], reserved1[1], reserved1[2]))
+                print("   [match_reg=[%s]]" %
+                      ", ".join(["%#010x" % x for x in match_reg]))
 
             if opts.extract:
                 extract_patch(opts, patch_start, patch_length, ucode_file,
@@ -152,6 +223,10 @@ def parse_options():
     parser.add_argument("container_file", nargs='+')
     parser.add_argument("-e", "--extract",
                         help="Dump each patch in container to the specified directory")
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Increase output verbosity level: provide once " +
+                             "to see additional information about patches, " +
+                             "twice to see all the information available")
     opts = parser.parse_args()
 
     for f in opts.container_file:

--- a/amd_ucode_info.py
+++ b/amd_ucode_info.py
@@ -202,8 +202,14 @@ def parse_ucode_file(opts, path, start_offset):
             print("ERROR: Missing magic number at beginning of container")
             return
 
+        # Check the equivalence table type
+        eq_table_type = read_int32(ucode_file)
+        if eq_table_type != EQ_TABLE_TYPE:
+            print("ERROR: Invalid equivalence table identifier: %#010x" %
+                  eq_table_type)
+            return
+
         # Read the equivalence table length
-        ucode_file.seek(start_offset + EQ_TABLE_LEN_OFFSET, 0)
         eq_table_len = read_int32(ucode_file)
 
         ids = parse_equiv_table(opts, ucode_file, start_offset, eq_table_len)

--- a/amd_ucode_info.py
+++ b/amd_ucode_info.py
@@ -94,7 +94,8 @@ def parse_equiv_table(opts, ucode_file, start_offset, eq_table_len):
             if cpu_id in table[equiv_id]:
                 print(("WARNING: Duplicate CPUID %#010x (%s) " +
                        "in the equivalence table for equiv_id %#06x ") %
-                      (cpu_id, fms2str(cpuid2fms(cpu_id)), equiv_id))
+                      (cpu_id, fms2str(cpuid2fms(cpu_id)), equiv_id),
+                      file=sys.stderr)
 
             if cpu_id in cpuid_map:
                 if equiv_id != cpuid_map[cpu_id]:
@@ -102,7 +103,7 @@ def parse_equiv_table(opts, ucode_file, start_offset, eq_table_len):
                            "are present in the equivalence table for CPUID " +
                            "%#010x (%s)") %
                           (equiv_id, cpuid_map[cpu_id], cpu_id,
-                           fms2str(cpuid2fms(cpu_id))))
+                           fms2str(cpuid2fms(cpu_id))), file=sys.stderr)
             else:
                 cpuid_map[cpu_id] = equiv_id
 
@@ -197,7 +198,7 @@ def merge_mc(opts, out_path, table, patches):
             print(("WARNING: Duplicate CPUID %#010x (%s) in the equivalence " +
                    "table for equiv_id %#06x ") %
                   (entry.cpuid, fms2str(cpuid2fms(entry.cpuid)),
-                   entry.equiv_id))
+                   entry.equiv_id), file=sys.stderr)
         else:
             equivid_map[entry.equiv_id][entry.cpuid] = entry
 
@@ -207,7 +208,7 @@ def merge_mc(opts, out_path, table, patches):
                        "are present in the equivalence table for CPUID " +
                        "%#010x (%s)") %
                       (entry.equiv_id, cpuid_map[entry.cpuid], entry.cpuid,
-                       fms2str(cpuid2fms(entry.cpuid))))
+                       fms2str(cpuid2fms(entry.cpuid))), file=sys.stderr)
             else:
                 cpuid_map[entry.cpuid] = entry.equiv_id
 
@@ -288,14 +289,15 @@ def parse_ucode_file(opts, path, start_offset):
         # Check magic number
         ucode_file.seek(start_offset, 0)
         if ucode_file.read(4) != b'DMA\x00':
-            print("ERROR: Missing magic number at beginning of container")
+            print("ERROR: Missing magic number at beginning of container",
+                  file=sys.stderr)
             return (None, None, None)
 
         # Check the equivalence table type
         eq_table_type = read_int32(ucode_file)
         if eq_table_type != EQ_TABLE_TYPE:
             print("ERROR: Invalid equivalence table identifier: %#010x" %
-                  eq_table_type)
+                  eq_table_type, file=sys.stderr)
             return (None, None, None)
 
         # Read the equivalence table length
@@ -316,7 +318,8 @@ def parse_ucode_file(opts, path, start_offset):
                 return (cursor, table, patches)
             patch_type = int.from_bytes(patch_type_bytes, 'little')
             if patch_type != PATCH_TYPE:
-                print("Invalid patch identifier: %#010x" % (patch_type))
+                print("Invalid patch identifier: %#010x" % (patch_type),
+                      file=sys.stderr)
                 return (None, table, patches)
 
             patch_length = read_int32(ucode_file)
@@ -363,7 +366,7 @@ def parse_ucode_file(opts, path, start_offset):
 
             if equiv_id not in ids:
                 print("Patch equivalence id not present in equivalence table (%#06x)"
-                      % (equiv_id))
+                      % (equiv_id), file=sys.stderr)
                 print(("  Family=???? Model=???? Stepping=????: " +
                        "Patch=%#010x Length=%u bytes%s")
                       % (ucode_level, patch_length, add_info))
@@ -436,9 +439,10 @@ def parse_options():
 
     for f in opts.container_file:
         if not os.path.isfile(f):
-            parser.print_help()
-            print()
-            print("ERROR: Container file \"%s\" does not exist" % f)
+            parser.print_help(file=sys.stderr)
+            print(file=sys.stderr)
+            print("ERROR: Container file \"%s\" does not exist" % f,
+                  file=sys.stderr)
             sys.exit()
 
     return opts

--- a/amd_ucode_info.py
+++ b/amd_ucode_info.py
@@ -202,15 +202,15 @@ def parse_ucode_file(opts, path, start_offset):
             if equiv_id not in ids:
                 print("Patch equivalence id not present in equivalence table (%#06x)"
                       % (equiv_id))
-
-                cursor = cursor + patch_length + 8
-                continue
-
-            # The cpu_id is the equivalent to CPUID_Fn00000001_EAX
-            for cpuid in ids[equiv_id]:
-                print("  %s: Patch=%#010x Length=%u bytes%s"
-                      % (fms2str(cpuid2fms(cpuid)), ucode_level, patch_length,
-                         add_info))
+                print(("  Family=???? Model=???? Stepping=????: " +
+                       "Patch=%#010x Length=%u bytes%s")
+                      % (ucode_level, patch_length, add_info))
+            else:
+                # The cpu_id is the equivalent to CPUID_Fn00000001_EAX
+                for cpuid in ids[equiv_id]:
+                    print("  %s: Patch=%#010x Length=%u bytes%s"
+                          % (fms2str(cpuid2fms(cpuid)), ucode_level,
+                             patch_length, add_info))
 
             if opts.verbose >= VERBOSE_DEBUG:
                 print(("   [data_code=%#010x, mc_patch_data_id=%#06x, " +

--- a/amd_ucode_info.py
+++ b/amd_ucode_info.py
@@ -78,7 +78,10 @@ def parse_equiv_table(opts, ucode_file, start_offset, eq_table_len):
         res = read_int16(ucode_file)
 
         if equiv_id != 0:
-            table[equiv_id] = cpu_id
+            if equiv_id not in table:
+                table[equiv_id] = []
+
+            table[equiv_id].append(cpu_id)
 
         if opts.verbose >= VERBOSE_DEBUG:
             print((" [equiv entry@%#010x: cpuid %#010x, equiv id %#06x, " +
@@ -203,12 +206,11 @@ def parse_ucode_file(opts, path, start_offset):
                 cursor = cursor + patch_length + 8
                 continue
 
-            cpu_id = ids[equiv_id]
-
             # The cpu_id is the equivalent to CPUID_Fn00000001_EAX
-            print("  %s: Patch=%#010x Length=%u bytes%s"
-                  % (fms2str(cpuid2fms(cpu_id)), ucode_level, patch_length,
-                     add_info))
+            for cpuid in ids[equiv_id]:
+                print("  %s: Patch=%#010x Length=%u bytes%s"
+                      % (fms2str(cpuid2fms(cpuid)), ucode_level, patch_length,
+                         add_info))
 
             if opts.verbose >= VERBOSE_DEBUG:
                 print(("   [data_code=%#010x, mc_patch_data_id=%#06x, " +


### PR DESCRIPTION
This patch set implements several various things, but overall it is aimed at the following: make it possible to work with the files usually present on the system and implement some minimal manipulation abilities to be able to affect the contents of these files in a meaningful way.  This includes:
 * Supporting passing of multiple container files in the arguments
 * Supporting of multiple containers in a single file (as it may be the case in AuthenticAMD.bin in the early cpio)
 * Supporting splitting and merging container files

Also, it includes various fixes and improvements, such as:
 * Proper handling of multiple CPUIDs per equiv_id
 * Implementation of some sanity checking of the equivalence table
 * Printing of microcode release date and its offset in the file
 * Reporting of the diagnostic messages to stderr and returning non-zero exit code on error